### PR TITLE
[#21] refactor : 증상 추출 로직 수정

### DIFF
--- a/routes/name.py
+++ b/routes/name.py
@@ -39,6 +39,7 @@ def extract_and_match_medicine_name():
     if not matching_docs:
         session['retry_count'] = get_retry_count() + 1
         if get_retry_count >= 3:
+            session['retry_count'] = 0
             return jsonify({"error": translate_to_user_lang("3회 시도에도 약을 찾지 못했습니다. 처음으로 돌아갑니다."), "next": "/start", "response_type": "name_fail"}), 404
         return jsonify({"error": translate_to_user_lang(f"관련된 약 이름을 찾지 못했습니다. 다시 입력해주세요. ({get_retry_count()}/3)"), "next": "/name", "response_type": "name_fail"}), 404
 

--- a/routes/start.py
+++ b/routes/start.py
@@ -19,6 +19,8 @@ def start_route():
     # Flask 세션에 언어 정보 저장
     session['language'] = detect_language(user_input)
 
+    session['retry_count'] = 0
+    
     if user_input == "증상" or user_input == "symptom":
         return jsonify({
             "next": "/symptom",


### PR DESCRIPTION
#21
### 📌 작업 개요
- 증상 추출 로직을 수정합니다.

### 🧾 작업 배경
- symptom.py의 사용자 입력을 기반으로 증상을 추출하는 모델의 성공률이 지나치게 낮음.
- 3회 증상 추출 실패 후 다시 start -> symptom으로 이동했을 때 바로 3회 기회가 다 소진됨. 
- 3회 이름 추출 실패 후 다시 start -> name으로 이동했을 때 바로 3회 기회가 다 소진됨. 

### 🔧 변경 사항
- 증상 추출 모델에 프롬프트 수정과 학습 데이터를 추가합니다.
- name.py와 symptom.py에서 3회 추출 기회를 소진했을 경우 세션의 시도 횟수를 초기화합니다.

### ✅ 테스트 및 확인
- [x] 주요 예시 입력값에 대한 출력 결과 검증 완료
- [x] 로컬 테스트 기준 이상 없음